### PR TITLE
Fix tracked messages crash

### DIFF
--- a/src/Events/events/linkedMessageAdd.ts
+++ b/src/Events/events/linkedMessageAdd.ts
@@ -12,43 +12,48 @@ export default class LinkedMessageAddEvent extends BotEvent {
 
         const messageLinks = message.content.match(
             /https?:\/\/discord\.com\/channels\/\d+\/\d+\/\d+/g
-          );
+        );
         
-          if (messageLinks) {
+        if (messageLinks) {
             for (const link of messageLinks) {
-              // Extract channel ID and message ID from the link
-              const [, guildId, channelId, messageId] = link.match(
+                // Extract channel ID and message ID from the link
+                const [, guildId, channelId, messageId] = link.match(
                 /https?:\/\/discord\.com\/channels\/(\d+)\/(\d+)\/(\d+)/
-              );
+                );
         
-              const channel = await message.client.channels.fetch(channelId);
-              if (!channel) continue; // Skip if the channel is not available
-              if (channel.type !== ChannelType.GuildText) continue; // Skip if the channel is not a text channel
-              if (message.author.bot) continue; // Skip if the message author is a bot
-              if (message.channel.id != channelIds.staff) continue; // Skip if the channel is not #staff
-        
-              try {
-                const linkedMessage = await channel.messages.fetch(messageId);
-        
-                // Store the message information for tracking
-                const trackedMessage = {
-                  originalMessage: message,
-                  originalLink: link,
-                  guildId,
-                  channelId,
-                  messageId,
-                  content: linkedMessage.content,
-                  author: linkedMessage.author.tag,
-                  timestamp: Date.now(), // Add timestamp to track when the message was linked
-                };
-        
-                logger.command("New linked message: " + trackedMessage.content);
-                
-                // Add the tracked message to the map
-                services.state.state.trackedMessages.set(trackedMessage.messageId, trackedMessage);
-              } catch (error) {
-                logger.error(error);
-              }
+                try {
+                    const channel = await message.client.channels.fetch(channelId);
+                    if (!channel) continue; // Skip if the channel is not available
+                    if (channel.type !== ChannelType.GuildText) continue; // Skip if the channel is not a text channel
+                    if (message.author.bot) continue; // Skip if the message author is a bot
+                    if (message.channel.id != channelIds.staff) continue; // Skip if the channel is not #staff
+                    
+                    const linkedMessage = await channel.messages.fetch(messageId);
+            
+                    // Store the message information for tracking
+                    const trackedMessage = {
+                        originalMessage: message,
+                        originalLink: link,
+                        guildId,
+                        channelId,
+                        messageId,
+                        content: linkedMessage.content,
+                        author: linkedMessage.author.tag,
+                        timestamp: Date.now(), // Add timestamp to track when the message was linked
+                    };
+            
+                    logger.command("New linked message: " + trackedMessage.content);
+                    
+                    // Add the tracked message to the map
+                    services.state.state.trackedMessages.set(trackedMessage.messageId, trackedMessage);
+                } catch (error) {
+                    if (error.code === 50001) { // Missing access
+                        message.reply("I can't seem to see that channel, so I can't track that message. Sorry!");
+                        logger.warning("Tried tracking message id", messageId, "in channel id", channelId, "but lacked required permissions.");
+                    } else {
+                        logger.error(error);
+                    }
+                }
             }
         }
     }

--- a/src/Events/events/linkedMessageRemove.ts
+++ b/src/Events/events/linkedMessageRemove.ts
@@ -26,7 +26,11 @@ export default class LinkedMessageRemoveEvent extends BotEvent {
             } else if (messageId === message.id) {
               // Notify the channel about the deletion
               const channel = await message.client.channels.fetch(channelIds.staff) as TextChannel;
+
+              const filter = (m: Message) => m.channelId === channelIds.chatLog;
+
               const newMessage = await channel.awaitMessages({
+                filter,
                 max: 1,
                 time: 30000,
                 errors: ["time"],

--- a/src/Events/events/linkedMessageRemove.ts
+++ b/src/Events/events/linkedMessageRemove.ts
@@ -25,7 +25,7 @@ export default class LinkedMessageRemoveEvent extends BotEvent {
               }
             } else if (messageId === message.id) {
               // Notify the channel about the deletion
-              const channel = await message.client.channels.fetch(channelIds.staff) as TextChannel;
+              const channel = await message.client.channels.fetch(channelIds.chatLog) as TextChannel;
 
               const filter = (m: Message) => m.channelId === channelIds.chatLog;
 


### PR DESCRIPTION
This fixes #6.

Extends the try catch block to include fetching the channel as well as improved error logs to inform staff that we couldn't track the message.

As an extra fix and to improve understanding of how this feature works (and avoid a future bug due to race conditions), also limits waiting for messages for this feature to the chat log.