### PR TITLE
small fix to avoid annoying staff

### DIFF
--- a/src/Events/events/linkedMessageAdd.ts
+++ b/src/Events/events/linkedMessageAdd.ts
@@ -48,7 +48,8 @@ export default class LinkedMessageAddEvent extends BotEvent {
                     services.state.state.trackedMessages.set(trackedMessage.messageId, trackedMessage);
                 } catch (error) {
                     if (error.code === 50001) { // Missing access
-                        message.reply("I can't seem to see that channel, so I can't track that message. Sorry!");
+                        const notifChannel = await message.client.channels.fetch(channelIds.bilby) as TextChannel;
+                        notifChannel.send(`${link}. I can't seem to see that channel, so I can't track that message. Sorry!`);
                         logger.warning("Tried tracking message id", messageId, "in channel id", channelId, "but lacked required permissions.");
                     } else {
                         logger.error(error);


### PR DESCRIPTION
It could get annoying when staff posts a link from another staff channel and bilby disrupts the conversation, so instead I'm having him log it in the bilby spam channel.