### PR TITLE
Add more API endpoints

### DIFF
--- a/src/Services/BilbyAPI/index.ts
+++ b/src/Services/BilbyAPI/index.ts
@@ -10,7 +10,7 @@ export default class BilbyAPIService {
     protected caching: Caching = {
         memberCount: { value: null, lastCacheTimestamp: 0 },
         upcomingEvents: { value: [], lastCacheTimestamp: 0 },
-        staffMembers: { value: [], lastCacheTimestamp: 0 }
+        staffMembers: { value: { leadership: [], mods: [], helpers: [] }, lastCacheTimestamp: 0 }
     };
 
     constructor(client: Client) {
@@ -84,7 +84,11 @@ export default class BilbyAPIService {
 
             await guild.members.fetch(); // Fetch all members
 
-            this.caching.staffMembers.value = guild.members.cache.filter(member => member.roles.cache.has(roleIds.staff)).map(member => member.id);
+            this.caching.staffMembers.value = {
+                leadership: guild.members.cache.filter(member => member.roles.cache.has(roleIds.leadership)).map(member => { return { id: member.id, name: member.displayName, avatar: member.displayAvatarURL() } }),
+                mods: guild.members.cache.filter(member => member.roles.cache.has(roleIds.mod)).map(member => { return { id: member.id, name: member.displayName, avatar: member.displayAvatarURL() } }),
+                helpers: guild.members.cache.filter(member => member.roles.cache.has(roleIds.helper)).map(member => { return { id: member.id, name: member.displayName, avatar: member.displayAvatarURL() } }),
+            }
         }
 
         res.status(200).send(this.caching.staffMembers.value);
@@ -94,7 +98,7 @@ export default class BilbyAPIService {
 interface Caching {
     memberCount: { value: MemberCounts, lastCacheTimestamp: number},
     upcomingEvents: { value: UpcomingEvents[], lastCacheTimestamp: number },
-    staffMembers: { value: Snowflake[], lastCacheTimestamp: number }
+    staffMembers: { value: StaffMembers, lastCacheTimestamp: number }
 }
 
 interface MemberCounts {
@@ -109,4 +113,10 @@ interface UpcomingEvents {
     start: Date,
     url: string,
     image: string
+}
+
+interface StaffMembers {
+    leadership: { id: Snowflake, name: string, avatar: string }[],
+    mods: { id: Snowflake, name: string, avatar: string }[],
+    helpers: { id: Snowflake, name: string, avatar: string }[]
 }

--- a/src/Services/BilbyAPI/index.ts
+++ b/src/Services/BilbyAPI/index.ts
@@ -1,6 +1,6 @@
-import { Client, Guild, GuildScheduledEventPrivacyLevel, Status } from "discord.js";
+import { Client, Guild, GuildScheduledEventPrivacyLevel, Snowflake, Status } from "discord.js";
 import express, { Request, Response } from "express";
-import { THH_SERVER_ID } from "../../constants";
+import { THH_SERVER_ID, roleIds } from "../../constants";
 import * as logger from "../../logger";
 
 export default class BilbyAPIService {
@@ -9,7 +9,8 @@ export default class BilbyAPIService {
 
     protected caching: Caching = {
         memberCount: { value: null, lastCacheTimestamp: 0 },
-        upcomingEvents: { value: [], lastCacheTimestamp: 0 }
+        upcomingEvents: { value: [], lastCacheTimestamp: 0 },
+        staffMembers: { value: [], lastCacheTimestamp: 0 }
     };
 
     constructor(client: Client) {
@@ -29,6 +30,7 @@ export default class BilbyAPIService {
 
             this.app.get("/members", async (req, res) => await this.serverMembers(guild, req, res));
             this.app.get("/events", async (req, res) => await this.serverEvents(guild, req, res));
+            this.app.get("/staff", async (req, res) => await this.serverStaff(guild, req, res));
 
             this.app.listen(process.env.API_PORT, () => logger.bilby("Bilby API running on port", process.env.API_PORT));
         });
@@ -75,11 +77,24 @@ export default class BilbyAPIService {
 
         res.status(200).send(this.caching.upcomingEvents.value);
     }
+
+    async serverStaff(guild: Guild, req: Request, res: Response) {
+        if (Date.now() - this.caching.staffMembers.lastCacheTimestamp >= 1 * 60 * 1000) {
+            this.caching.staffMembers.lastCacheTimestamp = Date.now()
+
+            await guild.members.fetch(); // Fetch all members
+
+            this.caching.staffMembers.value = guild.members.cache.filter(member => member.roles.cache.has(roleIds.staff)).map(member => member.id);
+        }
+
+        res.status(200).send(this.caching.staffMembers.value);
+    }
 }
 
 interface Caching {
     memberCount: { value: MemberCounts, lastCacheTimestamp: number},
-    upcomingEvents: { value: UpcomingEvents[], lastCacheTimestamp: number }
+    upcomingEvents: { value: UpcomingEvents[], lastCacheTimestamp: number },
+    staffMembers: { value: Snowflake[], lastCacheTimestamp: number }
 }
 
 interface MemberCounts {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,7 @@ import * as devConstants from '../testingIds.json';
 
 export const roleIds = {
     staff: devConstants.roleIds.staff || "1073391142881722400",
+    helper: devConstants.roleIds.helper || "1079592438819205130",
     mod: devConstants.roleIds.mod || "960044331572547654",
     leadership: devConstants.roleIds.leadership || "1073388656183742514"
 }

--- a/testingIds.json
+++ b/testingIds.json
@@ -2,6 +2,7 @@
     "roleIds": {
         "staff": "",
         "mod": "",
+        "helper": "",
         "leadership": ""
     },
     "channelIds": {


### PR DESCRIPTION
Mainly site dev stuff, adds a `/staff` endpoint to the REST API which, when called, gives the following infomation about the staff members
- User ID
- User Display name
- User Avatar
in the following staff member "categories"
- Leadership
- Mods
- Helpers

This is used to power a staff member list on THH website.