### PR TITLE
Thread logging

### DIFF
--- a/src/Commands/text/toggle_thread_logging_blacklist.ts
+++ b/src/Commands/text/toggle_thread_logging_blacklist.ts
@@ -1,0 +1,46 @@
+import { ChannelType, Message, TextChannel } from "discord.js";
+import { Services } from "../../Services";
+import TextCommand, { TextCommandBuilder } from "../TextCommand";
+import { channelIds, roleIds } from "../../constants";
+
+export default class TogglePagingCommand extends TextCommand {
+    public data = new TextCommandBuilder()
+        .setName("toggle thread logging blacklist")
+        .setDescription("Toggles whether the thread/channel is logged as part of thread logging.")
+        .addAllowedRoles(roleIds.staff)
+        .allowInDMs(false);
+
+    async execute(message: Message, args: string[], services: Services) {
+        if (args[0].startsWith("<#") && args[0].endsWith(">")) args[0] = args[0].replace("<#", "").replace(">", "");
+
+        let channel = await message.guild.channels.fetch(args[0]);
+
+        if ([ChannelType.PublicThread, ChannelType.PrivateThread, ChannelType.AnnouncementThread].includes(channel.type)) {
+            // Blacklist thread.
+            let channelIndex = services.state.state.threadLogging.blacklistedThreads.indexOf(channel.id);
+
+            if (channelIndex == -1) {
+                services.state.state.threadLogging.blacklistedThreads.push(channel.id);
+            } else {
+                services.state.state.threadLogging.blacklistedThreads.splice(channelIndex, 1);
+            }
+
+            services.state.save();
+
+            message.reply(`Successfully **${channelIndex == -1 ? "added" : "removed"}** <#${channel.id}> ${channelIndex == -1 ? "to" : "from"} the blacklist. The thread will ${channelIndex == -1 ? "no longer " : ""}be logged in <#${channelIds.threadLog}>.`);
+        } else {
+            // Blacklist channel.
+            let channelIndex = services.state.state.threadLogging.blacklistedChannels.indexOf(channel.id);
+
+            if (channelIndex == -1) {
+                services.state.state.threadLogging.blacklistedChannels.push(channel.id);
+            } else {
+                services.state.state.threadLogging.blacklistedChannels.splice(channelIndex, 1);
+            }
+
+            services.state.save();
+
+            message.reply(`Successfully **${channelIndex == -1 ? "added" : "removed"}** <#${channel.id}> ${channelIndex == -1 ? "to" : "from"} the blacklist. The channel's threads will ${channelIndex == -1 ? "no longer " : ""}be logged in <#${channelIds.threadLog}>.`);
+        }
+    }
+}

--- a/src/Events/events/threadCreate.ts
+++ b/src/Events/events/threadCreate.ts
@@ -1,0 +1,27 @@
+import { ChannelType, Events, Message, TextChannel, ThreadChannel, Webhook, WebhookType } from "discord.js";
+import BotEvent from "../BotEvent";
+import { roleIds, channelIds } from "../../constants";
+import { Services } from "../../Services";
+import { isTHHorDevServer } from "../../Helper/EventsHelper";
+
+export default class ThreadCreateEvent extends BotEvent {
+    public eventName = Events.ThreadCreate;
+
+    async execute(services: Services, thread: ThreadChannel, newlyCreated: boolean) {
+        if (!newlyCreated) return;
+        if (!isTHHorDevServer(thread.guild.id)) return;
+        if (services.state.state.threadLogging.blacklistedChannels.includes(thread.parentId)) return;
+
+        let threadLog = await thread.guild.channels.fetch(channelIds.threadLog) as TextChannel;
+
+        await threadLog.send({
+            embeds: [
+                {
+                    "description": `**${thread.name}** (<#${thread.id}>) in <#${thread.parentId}>`,
+                    "title": "Thread Created",
+                    "color": 65283
+                }
+            ]
+        });
+    }
+}

--- a/src/Events/events/threadDelete.ts
+++ b/src/Events/events/threadDelete.ts
@@ -1,0 +1,26 @@
+import { ChannelType, Events, Message, TextChannel, ThreadChannel, Webhook, WebhookType } from "discord.js";
+import BotEvent from "../BotEvent";
+import { roleIds, channelIds } from "../../constants";
+import { Services } from "../../Services";
+import { isTHHorDevServer } from "../../Helper/EventsHelper";
+
+export default class ThreadDeleteEvent extends BotEvent {
+    public eventName = Events.ThreadDelete;
+
+    async execute(services: Services, thread: ThreadChannel) {
+        if (!isTHHorDevServer(thread.guild.id)) return;
+        if (services.state.state.threadLogging.blacklistedChannels.includes(thread.parentId)) return;
+
+        let threadLog = await thread.guild.channels.fetch(channelIds.threadLog) as TextChannel;
+
+        await threadLog.send({
+            embeds: [
+                {
+                    "description": `**${thread.name}** in <#${thread.parentId}>`,
+                    "title": "Thread Deleted",
+                    "color": 16711680
+                }
+            ]
+        });
+    }
+}

--- a/src/Events/events/threadMessage.ts
+++ b/src/Events/events/threadMessage.ts
@@ -1,0 +1,71 @@
+import { ChannelType, Events, Message, MessageType, TextChannel, ThreadChannel, Webhook, WebhookType } from "discord.js";
+import BotEvent from "../BotEvent";
+import { roleIds, channelIds } from "../../constants";
+import { Services } from "../../Services";
+import { isTHHorDevServer } from "../../Helper/EventsHelper";
+
+export default class ThreadMessageEvent extends BotEvent {
+    public eventName = Events.MessageCreate;
+
+    async execute(services: Services, message: Message) {
+        if (!isTHHorDevServer(message.guild.id)) return;
+        if (![ChannelType.PublicThread, ChannelType.PrivateThread, ChannelType.AnnouncementThread].includes(message.channel.type)) return;
+        if (services.state.state.threadLogging.blacklistedChannels.includes((message.channel as ThreadChannel).parentId)) return;
+        if (services.state.state.threadLogging.blacklistedThreads.includes(message.channel.id)) return;
+
+        let threadLog = await message.guild.channels.fetch(channelIds.threadLog) as TextChannel;
+
+        let webhooks = await threadLog.fetchWebhooks();
+
+        let webhooksWeOwn = webhooks.filter(webhook => webhook.applicationId == message.client.user.id);
+
+        let webhook: Webhook<WebhookType.Incoming> = null;
+
+        if (webhooksWeOwn.size == 0) {
+            // Webhook doesn't exist.
+            webhook = await threadLog.createWebhook({
+                name: "Thread Log Webhook"
+            });
+        } else {
+            webhook = webhooksWeOwn.first() as Webhook<WebhookType.Incoming>;
+        }
+
+        let embeds = [];
+
+        if (message.type == MessageType.Reply) {
+            let repliedMessage = await message.fetchReference();
+
+            embeds.push({
+                "description": repliedMessage.content,
+                "color": 5329233,
+                "author": {
+                    "name": repliedMessage.member.displayName,
+                    "icon_url": repliedMessage.member.displayAvatarURL()
+                },
+                "timestamp": repliedMessage.createdAt
+            });
+        }
+
+        await webhook.send({
+            content: message.content,
+            components: [
+                {
+                    "type": 1,
+                    "components": [
+                        {
+                            "type": 2,
+                            "style": 5,
+                            "label": "Jump to message",
+                            "url": message.url,
+                            "disabled": false
+                        }
+                    ]
+                }
+            ],
+            embeds,
+            files: message.attachments.map(attachment => attachment.url),
+            username: message.member.displayName,
+            avatarURL: message.member.displayAvatarURL()
+        });
+    }
+}

--- a/src/Services/State/index.ts
+++ b/src/Services/State/index.ts
@@ -7,6 +7,7 @@ const STATE_PATH = path.join(__dirname, "../../../state.json");
 const defaultState: State = {
     joinGate: true,
     trackedMessages: new Map<string, TrackedMessage>(),
+    threadLogging: { blacklistedThreads: [], blacklistedChannels: [] },
     pagedUsers: []
 }
 
@@ -33,7 +34,13 @@ export default class StateService {
 
     private setDefaultState(defaultStateObject, target) {
         for (let key in defaultStateObject) {
+            if (defaultStateObject[key] instanceof Array) {
+                if (target[key] == undefined) target[key] = [];
+                this.setDefaultState(defaultStateObject[key], target[key]);
+                continue;
+            } else
             if (defaultStateObject[key] instanceof Object) {
+                if (target[key] == undefined) target[key] = {};
                 this.setDefaultState(defaultStateObject[key], target[key]);
                 continue;
             }
@@ -68,7 +75,8 @@ export default class StateService {
 export interface State {
     joinGate: boolean,
     trackedMessages: Map<string, TrackedMessage>,
-    pagedUsers: Snowflake[];
+    threadLogging: ThreadLoggingState,
+    pagedUsers: Snowflake[]
 }
 
 export interface TrackedMessage {
@@ -81,3 +89,8 @@ export interface TrackedMessage {
     author: string,
     timestamp: number, // Add timestamp to track when the message was linked
 };
+
+export interface ThreadLoggingState {
+    blacklistedThreads: Snowflake[],
+    blacklistedChannels: Snowflake[]
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,6 +15,7 @@ export const channelIds = {
     chatLog: devConstants.channelIds.chatLog || "961201095038873630",
     mediaLog: devConstants.channelIds.mediaLog || "1098673855809204294",
     reactionLog: devConstants.channelIds.reactionLog || "1241199271022301266",
+    threadLog: devConstants.channelIds.threadLog || "",
     announcements: devConstants.channelIds.announcements || "961056736398172200"
 }
 

--- a/testingIds.json
+++ b/testingIds.json
@@ -13,6 +13,7 @@
         "chatLog": "",
         "mediaLog": "",
         "reactionLog": "",
+        "threadLog": "",
         "announcements": ""
     },
     "devIds": null


### PR DESCRIPTION
_This feature is still a draft and depends on various other work in progress features! Please don't merge!_

This PR introduces a feature known as Thread logging. The primary purpose of this feature is to ease moderation by consolidating messages sent in many threads into 1 channel that can be looked through the same as any other. It also logs when a thread is created and destroyed.

This also introduces a new command, `toggle thread logging blacklist`, which allows for adding threads (and parent channels) to a blacklist to ensure they are not logged, even if Bilby can see them. The primary purpose for this is to blacklist staff channels as well as blacklist widely-used channels that staff already actively check.