### PR TITLE
Add help command

### DIFF
--- a/src/Commands/TextCommand.ts
+++ b/src/Commands/TextCommand.ts
@@ -97,10 +97,11 @@ export class TextCommandBuilder {
      * @param description The description of the argument
      * @returns This TextCommandBuilder
      */
-    addArgument(name: string, description: string): TextCommandBuilder {
+    addArgument(name: string, description: string, required: boolean = true): TextCommandBuilder {
         this.arguments.push({
             name,
-            description
+            description,
+            required
         });
         return this;
     }
@@ -124,5 +125,6 @@ interface TextCommandPermissions {
 
 interface TextCommandArgument {
     name: string,
-    description: string
+    description: string,
+    required: boolean
 }

--- a/src/Commands/text/help.ts
+++ b/src/Commands/text/help.ts
@@ -29,7 +29,7 @@ export default class PingCommand extends TextCommand {
                 .setTitle(command.data.name)
                 .setDescription(`${!canExecuteCommand(command, message.member) ? ":warning: **Your permission level prevents you from running this command.**\n*See the bolded permission fields below for entries which apply to you.*\n\n" : ""}${command.data.description}`)
                 .setColor(16777215)
-            
+
             if (command.data.arguments.length != 0) {
                 embed.addFields(
                     { name: "Arguments", value: command.data.arguments.map(argument => `${argument.required ? `<${argument.name}>` : `[${argument.name}]`} - ${argument.description}`).join("\n") }
@@ -58,7 +58,7 @@ export default class PingCommand extends TextCommand {
                     { name: "User permissions", value: command.data.permissions.allowedUsers.map(user => `<@${user}>${message.author.id == user ? " (You)" : ""} ✅`).join("\n"), inline: true }
                 );
             }
-            
+
             embed.addFields(
                 { name: "Usage", value: `\`${process.env.PREFIX}${command.data.name}${command.data.arguments.length != 0? ` ${command.data.arguments.map(argument => argument.required ? `<${argument.name}>` : `[${argument.name}]`)}` : ""}\`` }
             )
@@ -81,7 +81,7 @@ export default class PingCommand extends TextCommand {
                 `\n\`\`\`\nWant more information on a command? Run \`${process.env.PREFIX}${this.data.name} <command name>\`.`
             );
 
-            paginatedMessage.send(message);
+            await paginatedMessage.send(message);
         }
     }
 }

--- a/src/Commands/text/help.ts
+++ b/src/Commands/text/help.ts
@@ -1,14 +1,87 @@
-import { Message } from "discord.js";
+import { EmbedBuilder, Message } from "discord.js";
 import { Services } from "../../Services";
 import TextCommand, { TextCommandBuilder } from "../TextCommand";
+import { PageBuilder } from "../../Helper/PaginationHelper";
+import { canExecuteCommand } from "../../Helper/PermissionHelper";
 
 export default class PingCommand extends TextCommand {
     public data = new TextCommandBuilder()
         .setName("help")
-        .setDescription("Lists ")
+        .setDescription("Shows a list of all text commands available to you, or about one specific command if provided.")
+        .addArgument("command", "The command you want information on", false)
         .allowInDMs(true);
 
     async execute(message: Message, args: string[], services: Services) {
-        await message.reply(`Pong! Websocket heartbeat is ${message.client.ws.ping}ms.`);
+        let allTextCommands = services.commands.textCommands;
+        let searchTerm = args.join(" ");
+
+        if (searchTerm != "") {
+            // Get specific command.
+            let command = allTextCommands.get(searchTerm);
+
+            if (command == undefined) {
+                await message.reply("Sorry, I couldn't find a command with that name. Please try again.");
+                return;
+            }
+
+
+            let embed = new EmbedBuilder()
+                .setTitle(command.data.name)
+                .setDescription(`${!canExecuteCommand(command, message.member) ? ":warning: **Your permission level prevents you from running this command.**\n*See the bolded permission fields below for entries which apply to you.*\n\n" : ""}${command.data.description}`)
+                .setColor(16777215)
+            
+            if (command.data.arguments.length != 0) {
+                embed.addFields(
+                    { name: "Arguments", value: command.data.arguments.map(argument => `${argument.required ? `<${argument.name}>` : `[${argument.name}]`} - ${argument.description}`).join("\n") }
+                );
+            }
+
+            let rolePermissions = command.data.permissions.allowedRoles.map(roleId => { return { role: { id: message.guild.roles.resolve(roleId).id, name: message.guild.roles.resolve(roleId).name }, allowed: true } })
+            rolePermissions.push(...command.data.permissions.deniedRoles.map(roleId => { return { role: { id: message.guild.roles.resolve(roleId).id, name: message.guild.roles.resolve(roleId).name }, allowed: false } }));
+
+            rolePermissions.push({
+                role: {
+                    id: "0",
+                    name: "**Everyone**"
+                },
+                allowed: false
+            });
+
+            if (rolePermissions.length > 1) {
+                embed.addFields(
+                    { name: "Role permissions", value: rolePermissions.map(roles => `${message.member.roles.cache.has(roles.role.id) ? `**${roles.role.name}**` : `${roles.role.name}`} ${roles.allowed ? "✅" : "🚫"}`).join("\n"), inline: true }
+                );
+            }
+
+            if (command.data.permissions.allowedUsers.length != 0) {
+                embed.addFields(
+                    { name: "User permissions", value: command.data.permissions.allowedUsers.map(user => `<@${user}>${message.author.id == user ? " (You)" : ""} ✅`).join("\n"), inline: true }
+                );
+            }
+            
+            embed.addFields(
+                { name: "Usage", value: `\`${process.env.PREFIX}${command.data.name}${command.data.arguments.length != 0? ` ${command.data.arguments.map(argument => argument.required ? `<${argument.name}>` : `[${argument.name}]`)}` : ""}\`` }
+            )
+
+            await message.reply({
+                embeds: [embed],
+                allowedMentions: { parse: ['users', 'roles'], repliedUser: true }
+            });
+        } else {
+            // List all commands and their descriptions.
+            let paginatedMessage = new PageBuilder(
+                "plain_text",
+                Array.from(allTextCommands, (entry) => entry[1]) // Take all the text commands as an array
+                    .filter(command => canExecuteCommand(command, message.member)) // Filter out all commands the user cannot run themselves.
+                    .sort()
+                    .map(command => `${command.data.name} - ${command.data.description}`) // Format the help output as "name - description"
+                    .join("\n") // Join into 1 string with each command as a newline...
+                    .match(/(?=[\s\S])(?:.*\n?){1,10}/g), // ... then split every 10 newlines for each page.
+                "Here's all the text-based commands you can run!\nAny commands you can't run are hidden.\n\n```\n",
+                `\n\`\`\`\nWant more information on a command? Run \`${process.env.PREFIX}${this.data.name} <command name>\`.`
+            );
+
+            paginatedMessage.send(message);
+        }
     }
 }

--- a/src/Commands/text/help.ts
+++ b/src/Commands/text/help.ts
@@ -1,0 +1,14 @@
+import { Message } from "discord.js";
+import { Services } from "../../Services";
+import TextCommand, { TextCommandBuilder } from "../TextCommand";
+
+export default class PingCommand extends TextCommand {
+    public data = new TextCommandBuilder()
+        .setName("help")
+        .setDescription("Lists ")
+        .allowInDMs(true);
+
+    async execute(message: Message, args: string[], services: Services) {
+        await message.reply(`Pong! Websocket heartbeat is ${message.client.ws.ping}ms.`);
+    }
+}

--- a/src/Helper/PaginationHelper.ts
+++ b/src/Helper/PaginationHelper.ts
@@ -76,7 +76,7 @@ export class PageBuilder {
     }
 
     /**
-     * Use the base embed for the message if the `type` was set to `embed`
+     * Use the base embed as the template for the message if the `type` was set to `embed`
      * @param embed The base embed to use
      */
     setBaseEmbed(embed: EmbedBuilder) {
@@ -85,9 +85,9 @@ export class PageBuilder {
     }
 
     /**
-     * Send the pager to the channel of the `message`
+     * Send the pager to the channel of the origin `message`
      * @param message
-     * @param inputTimeout Timeout in milliseconds before the button stop working
+     * @param inputTimeout Timeout in milliseconds before the buttons are disabled
      */
     async send(message: Message, inputTimeout = 600_000) {
         let sentMessage = await this.createMessage(await this.getContent(this.index), message);
@@ -109,8 +109,7 @@ export class PageBuilder {
             }
 
             await this.update(await this.getContent(this.index), sentMessage)
-
-            button.update({})
+            await button.update({})
         })
 
         collector.on("end", async () => {

--- a/src/Helper/PaginationHelper.ts
+++ b/src/Helper/PaginationHelper.ts
@@ -1,0 +1,102 @@
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle, ComponentType, EmbedBuilder, Message } from "discord.js";
+
+export class PageBuilder {
+    type: "plain_text" | "embed"
+    content: string[]
+    private baseEmbed: EmbedBuilder = new EmbedBuilder()
+    private index = 0
+    private controlDisabled = false
+
+    private backButton = new ButtonBuilder()
+        .setCustomId("back")
+        .setEmoji("◀")
+        .setStyle(ButtonStyle.Primary)
+        .setDisabled(true) //? since index by default is zero
+    private forwardButton = new ButtonBuilder()
+        .setCustomId("forward")
+        .setEmoji("▶")
+        .setStyle(ButtonStyle.Primary)
+
+    private control = new ActionRowBuilder<ButtonBuilder>()
+        .setComponents(this.backButton, this.forwardButton)
+
+    constructor(type: "plain_text" | "embed", content: string[]) {
+        this.content = content
+        this.type = type
+    }
+
+    private async updateControl(message: Message) {
+        this.backButton = this.backButton
+            .setDisabled(this.index <= 0 || this.controlDisabled)
+        this.forwardButton = this.forwardButton
+            .setDisabled(this.index >= this.content.length - 1 || this.controlDisabled)
+
+        this.control.setComponents(this.backButton, this.forwardButton)
+        await message.edit({
+            components: [this.control]
+        })
+    }
+
+    private async getContent(index: number) {
+        switch (this.type) {
+            case "embed":
+                this.baseEmbed.setDescription(this.content[index])
+                return {
+                    embeds: [this.baseEmbed],
+                    components: [this.control]
+                }
+            case "plain_text":
+                return {
+                    content: this.content[this.index],
+                    components: [this.control]
+                }
+        }
+    }
+
+    /**
+     * Use the base embed for the message if the `type` was set to `embed`
+     * @param embed The base embed to use
+     */
+    setBaseEmbed(embed: EmbedBuilder) {
+        if (this.type != "embed") throw new Error(`"type" must be "embed" to set a base embed`)
+        this.baseEmbed = embed
+    }
+
+    /**
+     * Send the pager to the channel of the `message`
+     * @param message
+     * @param inputTimeout Timeout in milliseconds before the button stop working
+     */
+    async send(message: Message, inputTimeout = 600_000) {
+        let sentMessage = await message.channel.send(
+            await this.getContent(this.index)
+        )
+
+        const collector = sentMessage.createMessageComponentCollector({
+            componentType: ComponentType.Button,
+            filter: i => i.user.id == message.author.id,
+            time: inputTimeout
+        })
+
+        collector.on("collect", async (button) => {
+            switch (button.customId) {
+                case "back":
+                    this.index--
+                    break
+                case "forward":
+                    this.index++
+                    break
+            }
+
+            await this.updateControl(sentMessage)
+            await sentMessage.edit(await this.getContent(this.index))
+
+            button.update({})
+        })
+
+        collector.on("end", async () => {
+            this.controlDisabled = true
+            await this.updateControl(sentMessage)
+        })
+    }
+}

--- a/src/Helper/PermissionHelper.ts
+++ b/src/Helper/PermissionHelper.ts
@@ -1,0 +1,32 @@
+// Permission-related helper functions.
+
+import { GuildMember } from "discord.js";
+import TextCommand from "../Commands/TextCommand";
+
+/**
+ * Checks whether the member can use the command.
+ * @param command The command to check permissions for.
+ * @param member The member running the command.
+ * @returns `true` if the member is allowed to run the command, `false` if not.
+ */
+export function canExecuteCommand(command: TextCommand, member: GuildMember) {
+    // User allows override role allows/denies.
+    let allowed = false;
+
+    // Gets list of current user's roles allowed to use the command
+    let allowedUserRoles = member.roles.cache.filter((_, snowflake) => command.data.permissions.allowedRoles.includes(snowflake));
+
+    // Gets list of current user's roles which deny use of the command
+    let deniedUserRoles = member.roles.cache.filter((_, snowflake) => command.data.permissions.deniedRoles.includes(snowflake));
+
+    if (allowedUserRoles.size != 0 || command.data.permissions.allowedRoles.length == 0)
+        allowed = true; // Either the user has a role that allows them to use the command, or there are no allowed roles, which implicitly allows all roles.
+
+    if (deniedUserRoles.size != 0)
+        allowed = false; // The user has a role that denies them from using the command.
+
+    if (command.data.permissions.allowedUsers.includes(member.user.id))
+        allowed = true; // The user's id is in the allowed users list.
+
+    return allowed;
+}


### PR DESCRIPTION
Unblocks #44.

This PR implements a help command for text-based commands, so that users don't have to guess at what a command does or what it's name is.

It also allows for searching a command and seeing it's arguments, the permissions required to use it, and an example of it being used.