### PR TITLE
Remove hardcoded endpoint url

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ PREFIX="..." # text command prefix, can be any length.
 MONGO_URL="" # connection URL for MongoDB database (should be in the form of: "mongodb://...")
 API_PORT=8080 # port that the BilbyAPI service will listen on. used for non-bilby related projects where data from bilby is needed.
 
+S3_ENDPOINT="..." # Endpoint to access S3
 S3_ACCESS_KEY="..." # Access key for S3
 S3_SECRET_KEY="..." # Secret key for S3
 ```

--- a/src/Services/S3/index.ts
+++ b/src/Services/S3/index.ts
@@ -13,7 +13,7 @@ export default class S3Service {
     
     constructor() {
         this.client = new MinioClient({
-            endPoint: "s3.heeler.house",
+            endPoint: process.env.S3_ENDPOINT,
             port: 443,
             useSSL: true,
             accessKey: process.env.S3_ACCESS_KEY,


### PR DESCRIPTION
Just removes the hardcoded endpoint URL and replaces it with an environment variable. All changes required on production are already done.